### PR TITLE
Change mmday to mm/day

### DIFF
--- a/miranda/hq/daily.py
+++ b/miranda/hq/daily.py
@@ -92,7 +92,7 @@ def guess_variable(meta, cf_table: Optional[dict]) -> str:
     return name
 
 
-cf_units = {"°C": "celsius", "mm": "mmday"}
+cf_units = {"°C": "celsius", "mm": "mm/day"}
 cf_frequency = {"Fin du pas journalier": "day", "Instantanée du pas horaire": "1h"}
 cf_attrs_names = {"x": "lon", "y": "lat", "z": "elevation", "nom": "site"}
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -88,9 +88,9 @@ class TestEnvCanVariables:
 
         assert set(codes) == {
             "air_temperature",
-            "precipitation_accumulation",
-            "rainfall_accumulation",
-            "snowfall_accumulation",
+            "precipitation_flux",
+            "liquid_precipitation_flux",
+            "solid_precipitation_flux",
         }
 
 


### PR DESCRIPTION
I don't really understand how Pint was parsing the previous value, but it gave precipitation 1000 times too large (like tens of meters in a day).