### PR TITLE
Add HQ hourly tasmin and tasmax and some CF fixes

### DIFF
--- a/miranda/hq/daily.py
+++ b/miranda/hq/daily.py
@@ -77,6 +77,7 @@ def guess_variable(meta, cf_table: Optional[dict]) -> str:
     }
 
     name = str()
+    table_name = None
     if v in corr:
         name = corr[v]
     else:
@@ -86,14 +87,16 @@ def guess_variable(meta, cf_table: Optional[dict]) -> str:
             elif meta["mesure"] == "Minimum":
                 name = "tasmin"
 
+            table_name = name + "_" + cf_frequency[meta["pas"]]
+
     if meta["pas"] != cf_table[name]["frequency"]:
         raise ValueError("Unexpected frequency.")
 
-    return name
+    return name, table_name or name
 
 
 cf_units = {"°C": "celsius", "mm": "mm/day"}
-cf_frequency = {"Fin du pas journalier": "day", "Instantanée du pas horaire": "1h"}
+cf_frequency = {"Fin du pas journalier": "day", "Instantanée du pas horaire": "1h", "Fin pas horaire": "1h"}
 cf_attrs_names = {"x": "lon", "y": "lat", "z": "elevation", "nom": "site"}
 
 
@@ -146,8 +149,8 @@ def to_cf(
         m[key] = converters.get(key, lambda x: x)(val)
 
     # Get default variable attributes
-    name = guess_variable(m, cf_table)
-    attrs = cf_table.get(name)
+    name, table_name = guess_variable(m, cf_table)
+    attrs = cf_table.get(table_name)
 
     # Add custom HQ attributes
     for key, val in cf_attrs_names.items():

--- a/miranda/hq/daily.py
+++ b/miranda/hq/daily.py
@@ -96,7 +96,7 @@ def guess_variable(meta, cf_table: Optional[dict]) -> str:
 
 
 cf_units = {"°C": "celsius", "mm": "mm/day"}
-cf_frequency = {"Fin du pas journalier": "day", "Instantanée du pas horaire": "1h", "Fin pas horaire": "1h"}
+cf_frequency = {"Fin du pas journalier": "day", "Instantanée du pas horaire": "1h", "Fin du pas horaire": "1h"}
 cf_attrs_names = {"x": "lon", "y": "lat", "z": "elevation", "nom": "site"}
 
 

--- a/miranda/hq/daily.py
+++ b/miranda/hq/daily.py
@@ -96,7 +96,11 @@ def guess_variable(meta, cf_table: Optional[dict]) -> str:
 
 
 cf_units = {"°C": "celsius", "mm": "mm/day"}
-cf_frequency = {"Fin du pas journalier": "day", "Instantanée du pas horaire": "1h", "Fin du pas horaire": "1h"}
+cf_frequency = {
+    "Fin du pas journalier": "day",
+    "Instantanée du pas horaire": "1h",
+    "Fin du pas horaire": "1h",
+}
 cf_attrs_names = {"x": "lon", "y": "lat", "z": "elevation", "nom": "site"}
 
 

--- a/miranda/hq/daily.py
+++ b/miranda/hq/daily.py
@@ -87,7 +87,7 @@ def guess_variable(meta, cf_table: Optional[dict]) -> str:
             elif meta["mesure"] == "Minimum":
                 name = "tasmin"
 
-            table_name = name + "_" + cf_frequency[meta["pas"]]
+            table_name = name + "_" + meta["pas"]
 
     if meta["pas"] != cf_table[name]["frequency"]:
         raise ValueError("Unexpected frequency.")

--- a/miranda/hq/daily.py
+++ b/miranda/hq/daily.py
@@ -89,7 +89,7 @@ def guess_variable(meta, cf_table: Optional[dict]) -> str:
 
             table_name = name + "_" + meta["pas"]
 
-    if meta["pas"] != cf_table[name]["frequency"]:
+    if meta["pas"] != cf_table[table_name or name]["frequency"]:
         raise ValueError("Unexpected frequency.")
 
     return name, table_name or name

--- a/miranda/hq/hq_cf_attrs.json
+++ b/miranda/hq/hq_cf_attrs.json
@@ -75,7 +75,7 @@
             "frequency": "1h",
             "standard_name": "relative_humidity",
             "units": "%",
-            "cell_methods": "time: mean",
+            "cell_methods": "time: point",
             "long_name": "Near-Surface Relative Humidity",
             "comment": "The relative humidity with respect to liquid water for T> 0 C, and with respect to ice for T<0 C.",
             "out_name": "hurs",
@@ -85,8 +85,8 @@
             "frequency": "1h",
             "standard_name": "wind_speed",
             "units": "m s-1",
-            "cell_methods": "time: mean",
-            "long_name": "Daily-Mean Near-Surface Wind Speed",
+            "cell_methods": "time: point",
+            "long_name": "Near-Surface Wind Speed",
             "comment": "Near-surface (usually, 10 meters) wind speed.",
             "out_name": "sfcWind",
             "type": "real"
@@ -95,8 +95,8 @@
             "frequency": "1h",
             "standard_name": "wind_direction",
             "units": "degree",
-            "cell_methods": "time: mean",
-            "long_name": "Daily-Mean Near-Surface Wind Direction",
+            "cell_methods": "time: point",
+            "long_name": "Near-Surface Wind Direction",
             "comment": "Near-surface (usually, 10 meters) direction from which wind originates.",
             "out_name": "sfcWindAz",
             "type": "real"
@@ -106,9 +106,9 @@
             "frequency": "1h",
             "standard_name": "surface_snow_thickness",
             "units": "m",
-            "cell_methods": "time: mean",
+            "cell_methods": "time: point",
             "long_name": "Snow Depth",
-            "comment": "The mean thickness of snow.",
+            "comment": "The thickness of snow.",
             "out_name": "snd",
             "type": "real"
         }

--- a/miranda/hq/hq_cf_attrs.json
+++ b/miranda/hq/hq_cf_attrs.json
@@ -31,7 +31,7 @@
             "out_name": "prlp",
             "type": "real"
         },
-        "tasmin": {
+        "tasmin_day": {
             "frequency": "day",
             "standard_name": "air_temperature",
             "units": "K",
@@ -41,12 +41,32 @@
             "out_name": "tasmin",
             "type": "real"
         },
-        "tasmax": {
+        "tasmax_day": {
             "frequency": "day",
             "standard_name": "air_temperature",
             "units": "K",
             "cell_methods": "time: maximum",
             "long_name": "Daily Maximum Near-Surface Air Temperature",
+            "comment": "Maximum near-surface (usually, 2 meter) air temperature.",
+            "out_name": "tasmax",
+            "type": "real"
+        },
+        "tasmin_1h": {
+            "frequency": "1h",
+            "standard_name": "air_temperature",
+            "units": "K",
+            "cell_methods": "time: minimum",
+            "long_name": "Hourly Minimum Near-Surface Air Temperature",
+            "comment": "Minimum near-surface (usually, 2 meter) air temperature.",
+            "out_name": "tasmin",
+            "type": "real"
+        },
+        "tasmax_1h": {
+            "frequency": "1h",
+            "standard_name": "air_temperature",
+            "units": "K",
+            "cell_methods": "time: maximum",
+            "long_name": "Hourly Maximum Near-Surface Air Temperature",
             "comment": "Maximum near-surface (usually, 2 meter) air temperature.",
             "out_name": "tasmax",
             "type": "real"

--- a/miranda/utils.py
+++ b/miranda/utils.py
@@ -90,9 +90,7 @@ def read_privileges(location: Union[Path, str], strict: bool = False) -> bool:
     try:
         if Path(location).exists():
             if os.access(location, os.R_OK):
-                msg = "{} is read OK!".format(
-                    dt.now().strftime("%Y-%m-%d %X"), location
-                )
+                msg = "{} is read OK!".format(location)
                 logging.info(msg)
                 return True
             msg = "Ensure read privileges for `{}`.".format(location)

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ commands =
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements_dev.txt
-    -e git://github.com/psf/black.git@master#egg=black
+    black
 commands =
     flake8 miranda tests
     black --check miranda tests


### PR DESCRIPTION
Hourly versions of tasmin and tasmax were missing from miranda's HQ parser. This PR adds them and works around the duplication problem (with the daily versions) by decoupling the variable name and it's name in the CF table.

Also, I added some CF fixes to better represent what the HQ csv file were describing: for RH, sfcwind, sfcwindAz and snd, HQ's data states that it is "Instantané du pas horaire", this the proper cell method string would be "time: point" (instead of "time: mean").