### PR TITLE
Establish time frequency

### DIFF
--- a/miranda/decode/_decoder.py
+++ b/miranda/decode/_decoder.py
@@ -276,6 +276,11 @@ class Decoder:
                 )
 
                 if found_freq in potential_times:
+                    logging.warning(
+                        "Time frequency found in dataset on analysis was found in filename. "
+                        f"Metadata for `{Path(file).name} is probably incorrect. "
+                        f"Basing fields on `{found_freq}`."
+                    )
                     return time_dictionary[found_freq]
                 elif found_freq == "month":
                     for f in ["Amon", "Omon", "monC", "monthly", "months", "mon"]:

--- a/miranda/decode/_decoder.py
+++ b/miranda/decode/_decoder.py
@@ -254,7 +254,10 @@ class Decoder:
                 time_units = data["time"].units
                 potential_time = time_units.split()[0]
 
-            if potential_time not in potential_times:
+            if potential_time in potential_times:
+                return time_dictionary[potential_time]
+
+            else:
                 logging.warning(
                     f"Frequency from metadata not found in filename: `{Path(file).name}`: "
                     "Performing more rigorous frequency checks."
@@ -278,13 +281,13 @@ class Decoder:
                 elif found_freq == "month":
                     for f in ["Amon", "Omon", "monC", "monthly", "months", "mon"]:
                         if f in potential_times:
-                            return f
+                            return time_dictionary[f]
                 else:
                     logging.warning(
-                        "Frequency found in dataset on analysis was not found in filename. "
-                        f"Using `{found_freq}`."
+                        "Time frequency found in dataset on analysis was not found in filename. "
+                        f"Basing fields on `{found_freq}`."
                     )
-                    return found_freq
+                    return time_dictionary[found_freq]
 
     @classmethod
     def decode_converted(cls, file: Union[PathLike, str]) -> dict:

--- a/miranda/decode/_decoder.py
+++ b/miranda/decode/_decoder.py
@@ -527,6 +527,7 @@ class Decoder:
             facets["domain"] = regridded_domain_found.group()
 
         # The logic here is awful, but the information is bad to begin with.
+        driving_model = None
         driving_institution_parts = str(data["driving_model_id"]).split("-")
         if driving_institution_parts[0] in INSTITUTIONS:
             driving_institution = driving_institution_parts[0]
@@ -536,10 +537,13 @@ class Decoder:
             driving_institution = "-".join(driving_institution_parts[:3])
         elif data["driving_model_id"].startswith("GFDL"):
             driving_institution = "NOAA-GFDL"
+            facets["driving_model"] = f"NOAA-GFDL-{data['driving_model_id']}"
         elif data["driving_model_id"].startswith("MPI-ESM"):
             driving_institution = "MPI-M"
+            facets["driving_model"] = f"MPI-M-{data['driving_model_id']}"
         elif data["driving_model_id"].startswith("HadGEM2"):
             driving_institution = "MOHC"
+            facets["driving_model"] = f"MOHC-{data['driving_model_id']}"
         else:
             raise AttributeError(
                 "driving_institution (from driving_model_id: "
@@ -547,13 +551,7 @@ class Decoder:
             )
 
         facets["driving_institution"] = driving_institution
-        if data["driving_model_id"].startswith("MPI-ESM"):
-            facets["driving_model"] = f"MPI-M-{data['driving_model_id']}"
-        elif data["driving_model_id"].startswith("GFDL"):
-            facets["driving_model"] = f"NOAA-GFDL-{data['driving_model_id']}"
-        elif data["driving_model_id"].startswith("HadGEM2"):
-            facets["driving_model"] = f"MOHC-{data['driving_model_id']}"
-        else:
+        if not driving_model:
             facets["driving_model"] = data["driving_model_id"]
         facets["format"] = "netcdf"
         facets["frequency"] = cls._decode_time_info(

--- a/miranda/decode/_decoder.py
+++ b/miranda/decode/_decoder.py
@@ -229,7 +229,7 @@ class Decoder:
                 return pd.to_timedelta(time_dictionary[potential_time])
             return time_dictionary[potential_time]
 
-        if data and not file:
+        if file and not data:
             file_parts = Path(file).name.split("_")
             potential_times = [
                 segment for segment in file_parts if segment in time_dictionary.keys()
@@ -258,7 +258,7 @@ class Decoder:
 
             else:
                 logging.warning(
-                    f"Frequency from metadata not found in filename: `{Path(file).name}`: "
+                    f"Frequency from metadata (`{potential_time}`) not found in filename (`{Path(file).name}`): "
                     "Performing more rigorous frequency checks."
                 )
                 if Path(file).is_file() and Path(file).suffix in [".nc", ".nc4"]:
@@ -276,7 +276,7 @@ class Decoder:
                 )
 
                 if found_freq in potential_times:
-                    return found_freq
+                    return time_dictionary[found_freq]
                 elif found_freq == "month":
                     for f in ["Amon", "Omon", "monC", "monthly", "months", "mon"]:
                         if f in potential_times:

--- a/miranda/decode/_decoder.py
+++ b/miranda/decode/_decoder.py
@@ -1,5 +1,4 @@
 import logging
-import multiprocessing
 import multiprocessing as mp
 import os
 import re
@@ -60,7 +59,7 @@ class Decoder:
         d: dict,
         fail_early: bool,
         proj: str,
-        lock: multiprocessing.Lock,
+        lock: mp.Lock,
         file: Union[str, Path],
     ) -> None:
         if proj is None:

--- a/miranda/decode/_decoder.py
+++ b/miranda/decode/_decoder.py
@@ -266,8 +266,6 @@ class Decoder:
                     if segment in time_dictionary.keys()
                 ]
                 potential_time = data["frequency"]
-                print(potential_time, ", ".join(potential_times))
-
                 if potential_time == "":
                     if hasattr(data, "time"):
                         time_units = data["time"].units
@@ -524,6 +522,9 @@ class Decoder:
         aws_keys = data.get("intake_esm_dataset_key")
         if aws_keys:
             facets["domain"] = aws_keys.split(".")[3]
+        regridded_domain_found = re.search(r"\w{3}-\d{2}i", data.get("title"))
+        if regridded_domain_found:
+            facets["domain"] = regridded_domain_found.group()
 
         # The logic here is awful, but the information is bad to begin with.
         driving_institution_parts = str(data["driving_model_id"]).split("-")

--- a/miranda/decode/_decoder.py
+++ b/miranda/decode/_decoder.py
@@ -590,12 +590,3 @@ class Decoder:
             pass
 
         return facets
-
-
-if __name__ == "__main__":
-    d = Decoder("cmip6")
-    d.decode(
-        [
-            "/tank/scenario/datasets/simulations/raw/CMIP/CMIP6/global/NIMS-KMA/KACE-1-0-G/historical/r1i1p1f1/day/tasmax/tasmax_Amon_KACE-1-0-G_historical_r1i1p1f1_gr_185001-201412.nc"
-        ]
-    )

--- a/miranda/decode/_decoder.py
+++ b/miranda/decode/_decoder.py
@@ -522,9 +522,12 @@ class Decoder:
         aws_keys = data.get("intake_esm_dataset_key")
         if aws_keys:
             facets["domain"] = aws_keys.split(".")[3]
-        regridded_domain_found = re.search(r"\w{3}-\d{2}i", data.get("title"))
-        if regridded_domain_found:
-            facets["domain"] = regridded_domain_found.group()
+
+        title = data.get("title")
+        if title:
+            regridded_domain_found = re.search(r"\w{3}-\d{2}i", title)
+            if regridded_domain_found:
+                facets["domain"] = regridded_domain_found.group()
 
         # The logic here is awful, but the information is bad to begin with.
         driving_model = None

--- a/miranda/decode/_time.py
+++ b/miranda/decode/_time.py
@@ -11,10 +11,10 @@ from miranda.scripting import LOGGING_CONFIG
 logging.config.dictConfig(LOGGING_CONFIG)
 
 __all__ = [
-    "date_parser",
     "DecoderError",
     "TIME_UNITS_TO_FREQUENCY",
     "TIME_UNITS_TO_TIMEDELTA",
+    "date_parser",
 ]
 
 TIME_UNITS_TO_FREQUENCY = {

--- a/miranda/decode/_time.py
+++ b/miranda/decode/_time.py
@@ -12,6 +12,7 @@ logging.config.dictConfig(LOGGING_CONFIG)
 
 __all__ = [
     "DecoderError",
+    "FREQUENCY_TO_POTENTIAL_TIME_UNITS",
     "TIME_UNITS_TO_FREQUENCY",
     "TIME_UNITS_TO_TIMEDELTA",
     "date_parser",
@@ -56,6 +57,11 @@ TIME_UNITS_TO_FREQUENCY = {
     "fixed": "fx",
     "fx": "fx",
 }
+
+FREQUENCY_TO_POTENTIAL_TIME_UNITS = dict()
+for key, value in TIME_UNITS_TO_FREQUENCY.items():
+    FREQUENCY_TO_POTENTIAL_TIME_UNITS.setdefault(value, list()).append(key)
+
 TIME_UNITS_TO_TIMEDELTA = {
     "hourly": "1h",
     "hours": "1h",

--- a/miranda/units.py
+++ b/miranda/units.py
@@ -82,7 +82,7 @@ def get_time_frequency(d: xr.Dataset):
     freq = xr.infer_freq(d.time)
 
     # Hacky workaround for irregular Monthly data
-    if freq is None or (1 < int(freq[:-1]) < 32 and freq.endswith("D")):
+    if freq is None or (1 < int(parse_offset(freq)[0]) < 32 and freq.endswith("D")):
         if (
             (d.diff("time") < pd.Timedelta(32, "D"))
             & (d.diff("time") > pd.Timedelta(27, "D"))
@@ -95,12 +95,12 @@ def get_time_frequency(d: xr.Dataset):
 
     time_units = {
         "s": "second",
-        "m": "minute",
+        "T": "minute",
         "h": "hour",
         "D": "day",
         "M": "month",
         "W": "week",
-        "Y": "year",
+        "A": "year",
     }
     if offset[1] in ["S", "H"]:
         offset[1] = offset[1].lower()

--- a/miranda/units.py
+++ b/miranda/units.py
@@ -1,5 +1,6 @@
 import re
 
+import pandas as pd
 import pint
 import xarray as xr
 from pint import Unit
@@ -79,8 +80,17 @@ def units2pint(value: str) -> Unit:
 
 def get_time_frequency(d: xr.Dataset):
     freq = xr.infer_freq(d.time)
-    if freq is None:
-        raise TypeError()
+
+    # Hacky workaround for irregular Monthly data
+    if freq is None or (1 < int(freq[:-1]) < 32 and freq.endswith("D")):
+        if (
+            (d.diff("time") < pd.Timedelta(32, "D"))
+            & (d.diff("time") > pd.Timedelta(27, "D"))
+        ).all():
+            freq = "1M"
+        else:
+            raise TypeError()
+
     offset = [int(parse_offset(freq)[0]), parse_offset(freq)[1]]
 
     time_units = {
@@ -88,10 +98,11 @@ def get_time_frequency(d: xr.Dataset):
         "m": "minute",
         "h": "hour",
         "D": "day",
+        "M": "month",
         "W": "week",
         "Y": "year",
     }
-    if offset[1] in ["S", "M", "H"]:
+    if offset[1] in ["S", "H"]:
         offset[1] = offset[1].lower()
     offset_meaning = time_units[offset[1]]
     return offset, offset_meaning


### PR DESCRIPTION
Closes #47

- Addresses an issue with unreliable time frequencies in metadata of datasets

Working output:
```
2022-06-03 16:35:27,612 [INFO] root: Deciphering metadata with project = 'cmip6'
2022-06-03 16:35:27,756 [WARNING] root: Frequency from metadata not found in filename: `tasmax_Amon_KACE-1-0-G_historical_r1i1p1f1_gr_185001-201412.nc`: Performing more rigorous frequency checks.
Deciphered the following from tasmax_Amon_KACE-1-0-G_historical_r1i1p1f1_gr_185001-201412.nc: dict_items([('activity', 'CMIP'), ('date', '185001-201412'), ('domain', 'global'), ('experiment', 'historical'), ('format', 'netcdf'), ('frequency', 'mon'), ('grid_label', 'gr'), ('institution', 'NIMS-KMA'), ('member', 'r1i1p1f1'), ('modeling_realm', 'atmos'), ('processing_level', 'raw'), ('mip_era', 'CMIP6'), ('source', 'KACE-1-0-G'), ('timedelta', Timedelta('30 days 00:00:00')), ('type', 'simulation'), ('variable', 'tasmax'), ('version', 'vNotFound'), ('date_start', '1850-01-01'), ('date_end', '2014-12-01')])
```