### PR TITLE
add Actions-Version-Updater and use organizational Personal Access Tokens

### DIFF
--- a/.github/workflows/actions-version-updater.yml
+++ b/.github/workflows/actions-version-updater.yml
@@ -1,0 +1,24 @@
+name: GitHub Actions Version Updater
+
+on:
+  schedule:
+    # 12:00 AM on the first of every month
+    - cron:  '0 0 1 * *'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.1
+        with:
+          # This requires a personal access token with the privileges to push directly to `main`
+          token: ${{ secrets.ACTIONS_VERSION_UPDATER_TOKEN }}
+          persist-credentials: true
+      - name: Run GitHub Actions Version Updater
+        uses: saadmk11/github-actions-version-updater@v0.8.1
+        with:
+          token: ${{ secrets.ACTIONS_VERSION_UPDATER_TOKEN }}
+          committer_email: 'bumpversion[bot]@ouranos.ca'
+          committer_username: 'update-github-actions[bot]'
+          pull_request_title: '[bot] Update GitHub Action Versions'

--- a/.github/workflows/auto-bumpversion.yml
+++ b/.github/workflows/auto-bumpversion.yml
@@ -39,5 +39,5 @@ jobs:
         uses: ad-m/github-push-action@master
         with:
           force: false
-          github_token: ${{ secrets.BUMPVERSION_TOKEN }}
+          github_token: ${{ secrets.BUMP_VERSION_TOKEN }}
           branch: ${{ github.ref }}


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added


### What kind of change does this PR introduce?

* Updates Workflows to use Organization-scoped Access Tokens
* Updates workflow permissions to be very explicit (easier to understand what access is being used/asked for by each)

### Does this PR introduce a breaking change?

No.

### Other information:

The `ACTIONS_VERSIONS_UPDATER_TOKEN` and the `BUMP_VERSION_TOKEN` are Organization-scoped (`Hydrologie`) personal access tokens with the following permissions for repositories `xhydro`, `xdatasets` and `xhydro-testdata`:

ACTIONS_VERSIONS_UPDATER_TOKEN:
 - Contents: Read and Write
 - Metadata: Read-Only
 - Pull Requests: Read and Write
 - Workflows: Read and Write

BUMP_VERSION_TOKEN:
 - Contents: Read and Write
 - Metadata: Read-Only
 - Pull Requests: Read and Write

**Both are set to expire on January 1st, 2025**. After this point, anyone with maintainer access can generate new tokens and ask the `Hydrologie` admins to update the tokens so that workflows continue operating as normal.

For more information: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens