### PR TITLE
update cfia

### DIFF
--- a/src/miranda/convert/data/eccc_casr_cf_attrs.json
+++ b/src/miranda/convert/data/eccc_casr_cf_attrs.json
@@ -253,6 +253,8 @@
       "units": "kg m-2 s-1"
     },
     "A_CFIA_SFC": {
+      "_cf_variable_name": "cfia",
+      "cell_methods": "time: point",
       "long_name": "Analysis: Confidence Index of CaPA 24h Analysis at surface",
       "standard_name": "Confidence Index of CaPA 24h Analysis",
       "units": "%"


### PR DESCRIPTION
### What kind of change does this PR introduce?

* in eccc_casr_cf_attrs.json, added `_cf_variable_name` and `cell_methods` for `A_CFIA_SFC`. 

### Does this PR introduce a breaking change?
no

### Other information:

`A_CFIA_SFC` is the Confidence Index of CaPA 24h Analysis, which does not have a CF equivalent so I used `cfia` for the `_cf_variable_name`. 
