### PR TITLE
added prfr and prrp to casrv3.1 json

### DIFF
--- a/src/miranda/convert/data/eccc_casr_cf_attrs.json
+++ b/src/miranda/convert/data/eccc_casr_cf_attrs.json
@@ -320,7 +320,7 @@
     },
     "P_FR0_SFC": {
       "_units_context": "hydro",
-      "_cf_variable_name": "prfr", 
+      "_cf_variable_name": "prfr",
       "_clip_values": {
         "all": {
           "context": "hydro",
@@ -338,7 +338,7 @@
     },
     "P_PE0_SFC": {
       "_units_context": "hydro",
-      "_cf_variable_name": "prrp", 
+      "_cf_variable_name": "prrp",
       "_clip_values": {
         "all": {
           "context": "hydro",


### PR DESCRIPTION
### What kind of change does this PR introduce?

* Adds back CaSR v3.1 json entries for "P_FR0_SFC"  (Quantity of freezing precipitation (liquid water equivalent)) and "P_PE0_SFC" (Quantity of ice pellets (liquid water equivalent)), which were removed in [https://github.com/Ouranosinc/miranda/pull/272#pullrequestreview-3168698921](url)

### Does this PR introduce a breaking change?
No

### Other information:
