### PR TITLE
Fix CaSR global attrs

### DIFF
--- a/src/miranda/convert/data/eccc_casr_cf_attrs.json
+++ b/src/miranda/convert/data/eccc_casr_cf_attrs.json
@@ -41,7 +41,7 @@
     "realm": "atmos",
     "table_date": "2026-01-14",
     "table_id": "eccc",
-    "_terms_of_use":{
+    "_terms_of_use": {
       "casr-v31": "Original data source: https://hpfx.collab.science.gc.ca/~scar700/rcas-casr/data/CaSRv3.1/",
       "casr-v32": "Original data source: https://hpfx.collab.science.gc.ca/~scar700/rcas-casr/data/CaSRv3.2/"
     },


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [ ] CHANGELOG.rst has been updated (with summary of main changes).
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

In CaSR global attrs:
- Licence is spelled "license" everywhere
- Link in the `license` attr is updated
- in the `Remarks` attr,  CaSR versions are corrected and RDRS is changed to CaSR
- `terms_of_use` attr points to the correct data source
- `table_date` attr is updated to today's date

### Does this PR introduce a breaking change?
No

### Other information:
